### PR TITLE
Update and rename PrBoom-Plus_2_5_1_5.sh to PrBoom-Plus_2_5_1_6.sh

### DIFF
--- a/PrBoom-Plus_2_5_1_6.sh
+++ b/PrBoom-Plus_2_5_1_6.sh
@@ -16,6 +16,21 @@ DOOM_EXE_NAME="prboom-plus"
 DOOM_OPTIONS=""
 DOOM_LIB_PATH="$DOOM_HOME_DIR/arm-linux-gnueabihf:$DOOM_HOME_DIR/arm-linux-gnueabihf/pulseaudio"
 
+
+echo "Choose a .wad file: "
+
+wadlist=($DOOM_HOME_DIR/*.wad)                              # Get list of .wad files in the Doom home dir
+for i in "${!wadlist[@]}"
+do
+  wadfiles[i]="${wadlist[i]##*/}"                           # Get only the filesnames
+  echo $((i+1))" -" "${wadfiles[i]}"                        # Add 1 to the array index so the user can choose starting with 1, rather than 0
+done
+
+read -p "Choice: " wadchoice
+
+DOOM_OPTIONS="$DOOM_OPTIONS ${wadfiles[((wadchoice-1))]}"   # Add wad name to $DOOM_OPTIONS but subtract 1 since we added one earlier
+
+
 echo "Setting Video mode..."
 vmode -r 640 480 idx8
 
@@ -28,7 +43,4 @@ export HOME="$DOOM_HOME_DIR"
 
 cd $DOOM_HOME_DIR
 echo "Starting PrBoom-Plus :)"
-taskset $DOOM_CPU_MASK "$DOOM_HOME_DIR/$DOOM_EXE_NAME" $DOOM_OPTIONS 
-
-
-
+taskset $DOOM_CPU_MASK "$DOOM_HOME_DIR/$DOOM_EXE_NAME" $DOOM_OPTIONS


### PR DESCRIPTION
I added a few lines that list all of the .wad files in $DOOM_HOME_DIR and lets the user pick which .wad to load.

I'm not sure what the prboom-plus.wad file is, so I'm not sure if it should be included in the list. (I suspect it's the shareware wad of Doom 2?)

The last line is showing up because I have a habit of removing trailing extra spaces and empty lines, sorry, haha.